### PR TITLE
Issue/VSIX-66 - Support for Arm64

### DIFF
--- a/Lombiq.Vsix.Orchard/source.extension.vsixmanifest
+++ b/Lombiq.Vsix.Orchard/source.extension.vsixmanifest
@@ -21,6 +21,15 @@
         <InstallationTarget Version="[17.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
             <ProductArchitecture>amd64</ProductArchitecture>
         </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Community">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Pro">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
+        <InstallationTarget Version="[16.0,18.0)" Id="Microsoft.VisualStudio.Enterprise">
+            <ProductArchitecture>arm64</ProductArchitecture>
+        </InstallationTarget>
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />


### PR DESCRIPTION
[VSIX-66](https://lombiq.atlassian.net/browse/VSIX-66)
Added support for Visual Studio Community, Pro and Enterprise on Arm64 Architecture (Install Targets)
Fixes #41

[VSIX-66]: https://lombiq.atlassian.net/browse/VSIX-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ